### PR TITLE
Add support for constructor arguments and contract flattening

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,16 @@ module.exports = {
   /* ... rest of truffle-config */
 
   api_keys: {
-    etherscan: 'MY_API_KEY'
+    etherscan: 'MY_API_KEY',
   }
+}
+```
+5. If you are using a flattening tool, add the path to the flattened contracts
+```js
+module.exports = {
+  /* ... rest of truffle-config */
+
+  flattenedLocation: "./.flattened" // optional
 }
 ```
 
@@ -56,7 +64,7 @@ This plugin gets compiler optimisation settings from the truffle config file, so
 ## Limitations & Roadmap
 This plugin is in a very early version, so there is still functionality missing. Below is a non-exhaustive list of features that are currently missing from the plugin, that will be added in a later release.
 
-* The plugin only works with single file contracts (i.e. no import flattening)
+* The plugin only works with single file contracts - flattening must be done beforehand
 * The plugin has no external library support
 * The plugin has no constructor arguments support
 * The plugin has no graceful error handling, so be sure to follow the usage exactly

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ This plugin gets compiler optimisation settings from the truffle config file, so
 ## Limitations & Roadmap
 This plugin is in a very early version, so there is still functionality missing. Below is a non-exhaustive list of features that are currently missing from the plugin, that will be added in a later release.
 
-* The plugin only works with single file contracts (i.e. no import flattening)
-* The plugin has no external library support
-* The plugin has no constructor arguments support
 * The plugin has no graceful error handling, so be sure to follow the usage exactly
 * The plugin can only verify one smart contract at a time, instead of automatically verifying all deployed contracts
 * There is no automatic testing / build process in place

--- a/README.md
+++ b/README.md
@@ -30,16 +30,8 @@ module.exports = {
   /* ... rest of truffle-config */
 
   api_keys: {
-    etherscan: 'MY_API_KEY',
+    etherscan: 'MY_API_KEY'
   }
-}
-```
-5. If you are using a flattening tool, add the path to the flattened contracts
-```js
-module.exports = {
-  /* ... rest of truffle-config */
-
-  flattenedLocation: "./.flattened" // optional
 }
 ```
 
@@ -64,7 +56,7 @@ This plugin gets compiler optimisation settings from the truffle config file, so
 ## Limitations & Roadmap
 This plugin is in a very early version, so there is still functionality missing. Below is a non-exhaustive list of features that are currently missing from the plugin, that will be added in a later release.
 
-* The plugin only works with single file contracts - flattening must be done beforehand
+* The plugin only works with single file contracts (i.e. no import flattening)
 * The plugin has no external library support
 * The plugin has no constructor arguments support
 * The plugin has no graceful error handling, so be sure to follow the usage exactly

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,8 +263,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "sol-merger": {
-      "version": "github:vinceau/sol-merger#29023727c7867cd8fd46d4bc205e3ebdcb2e41c0",
-      "from": "github:vinceau/sol-merger",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/sol-merger/-/sol-merger-0.1.4.tgz",
+      "integrity": "sha512-IhwwwFpbKUT+FJkJ0cEdqRJLXBh9hDPhWjKQyS4xwlTuYu4z5Sq4XfYN8qa107hiYk2ZERHYjsOvZnfnDsBwbw==",
       "requires": {
         "bluebird": "^3.5.3",
         "cli-color": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
     "await-sleep": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/await-sleep/-/await-sleep-0.0.1.tgz",
@@ -18,12 +23,111 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bluebird": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
         "ms": "^2.1.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "follow-redirects": {
@@ -34,20 +138,160 @@
         "debug": "^3.2.6"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sol-merger": {
+      "version": "github:vinceau/sol-merger#84bcab712af8999177749cabdcee1921e3a275da",
+      "from": "github:vinceau/sol-merger",
+      "requires": {
+        "bluebird": "^3.5.3",
+        "cli-color": "^1.4.0",
+        "commander": "^2.19.0",
+        "debug": "^3.2.6",
+        "fs-extra": "^7.0.1",
+        "glob": "^7.1.2"
+      }
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,7 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "sol-merger": {
-      "version": "github:vinceau/sol-merger#84bcab712af8999177749cabdcee1921e3a275da",
+      "version": "github:vinceau/sol-merger#29023727c7867cd8fd46d4bc205e3ebdcb2e41c0",
       "from": "github:vinceau/sol-merger",
       "requires": {
         "bluebird": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "await-sleep": "0.0.1",
     "axios": "^0.18.0",
     "querystring": "^0.2.0",
-    "sol-merger": "github:vinceau/sol-merger"
+    "sol-merger": "^0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "await-sleep": "0.0.1",
     "axios": "^0.18.0",
-    "querystring": "^0.2.0"
+    "querystring": "^0.2.0",
+    "sol-merger": "github:vinceau/sol-merger"
   }
 }

--- a/verify.js
+++ b/verify.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const axios = require('axios')
 const querystring = require('querystring')
 const sleep = require('await-sleep')
@@ -54,6 +55,7 @@ const parseConfig = (config) => {
   const networkId = (config.networks[config.network] || {}).network_id || 4
   const apiUrl = API_URLS[networkId]
   const apiKey = config.api_keys.etherscan
+  const flattenedLocation = config.flattenedLocation
   const contractName = config._[1]
   const workingDir = config.working_directory
   const contractsBuildDir = config.contracts_build_directory
@@ -74,8 +76,15 @@ const parseConfig = (config) => {
 
 module.exports = async (config) => {
   const options = parseConfig(config)
+
   const artifactPath = `${options.contractsBuildDir}/${options.contractName}.json`
   const artifact = require(artifactPath)
+
+  if (options.flattenedLocation) {
+    const flattenedPath = `${options.flattenedLocation}/${options.contractName}.sol`
+    const source = new Promise((resolve, reject) => fs.readFile(flattenedPath, (err, data) => err ? reject(err) : resolve(data)));
+    artifact.source = source;
+  }
 
   try {
     const res = await sendVerifyRequest(artifact, options)

--- a/verify.js
+++ b/verify.js
@@ -85,6 +85,7 @@ const parseConfig = (config) => {
     contractName,
     workingDir,
     contractsBuildDir,
+    flattenedLocation,
     // Note: API docs state enabled = 0, disbled = 1, but empiric evidence suggests reverse
     optimizationUsed: optimizerSettings.enabled ? 1 : 0,
     runs: optimizerSettings.runs
@@ -99,7 +100,7 @@ module.exports = async (config) => {
 
   if (options.flattenedLocation) {
     const flattenedPath = `${options.flattenedLocation}/${options.contractName}.sol`
-    const source = new Promise((resolve, reject) => fs.readFile(flattenedPath, (err, data) => err ? reject(err) : resolve(data)));
+    const source = fs.readFileSync(flattenedPath, "utf8");
     artifact.source = source;
   }
 

--- a/verify.js
+++ b/verify.js
@@ -28,6 +28,7 @@ const fetchConstructorValues = async (artifact, options) => {
     // the last part of the transaction data is the constructor parameters
     return res.data.result[0].input.substring(bytecodeLength)
   }
+  console.error("Failed to fetch constructor arguments");
   return "";
 }
 

--- a/verify.js
+++ b/verify.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const axios = require('axios')
 const querystring = require('querystring')
 const sleep = require('await-sleep')
@@ -93,7 +92,6 @@ const parseConfig = (config) => {
 
 module.exports = async (config) => {
   const options = parseConfig(config)
-
   const artifactPath = `${options.contractsBuildDir}/${options.contractName}.json`
   const artifact = require(artifactPath)
 

--- a/verify.js
+++ b/verify.js
@@ -25,7 +25,7 @@ const fetchConstructorValues = async (artifact, options) => {
   );
   if (res.data && res.data.status === '1') {
     const bytecodeLength = artifact.bytecode.length;
-    // the last bit of the transaction data is the constructor parameters
+    // the last part of the transaction data is the constructor parameters
     return res.data.result[0].input.substring(bytecodeLength)
   }
 	return "";

--- a/verify.js
+++ b/verify.js
@@ -1,7 +1,7 @@
 const axios = require('axios')
 const querystring = require('querystring')
 const sleep = require('await-sleep')
-const flatten = require('sol-merger');
+const merge = require('sol-merger');
 
 const API_URLS = {
   [1]: 'https://api.etherscan.io/api',
@@ -33,14 +33,14 @@ const fetchConstructorValues = async (artifact, options) => {
 
 const sendVerifyRequest = async (artifact, options) => {
   const encodedConstructorArgs = await fetchConstructorValues(artifact, options);
-  const flattenedSource = await flatten(artifact.sourcePath);
+  const mergedSource = await merge(artifact.sourcePath);
   const postQueries = {
       apikey: options.apiKey,
       module: 'contract',
       action: 'verifysourcecode',
       // TODO: detect deployed networks
       contractaddress: artifact.networks[`${options.networkId}`].address,
-      sourceCode: flattenedSource,
+      sourceCode: mergedSource,
       contractname: artifact.contractName,
       compilerversion: `v${artifact.compiler.version.replace('.Emscripten.clang', '')}`,
       optimizationUsed: options.optimizationUsed,

--- a/verify.js
+++ b/verify.js
@@ -28,7 +28,7 @@ const fetchConstructorValues = async (artifact, options) => {
     // the last part of the transaction data is the constructor parameters
     return res.data.result[0].input.substring(bytecodeLength)
   }
-	return "";
+  return "";
 }
 
 const sendVerifyRequest = async (artifact, options) => {


### PR DESCRIPTION
This PR adds support for constructor arguments and contract flattening. It uses the Etherscan API itself to fetch the encoded constructor arguments, and uses the [`sol-merger`](https://www.npmjs.com/package/sol-merger) npm package for merging source code.