### PR TITLE
Fix merge import

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -1,7 +1,7 @@
 const axios = require('axios')
 const querystring = require('querystring')
 const sleep = require('await-sleep')
-const merge = require('sol-merger');
+const { merge } = require('sol-merger');
 
 const API_URLS = {
   [1]: 'https://api.etherscan.io/api',


### PR DESCRIPTION
The interface in `sol-merger` had changed so there is no longer a default import. This fixes the import syntax to reflect that.