### PR TITLE
Add option for adding preamble to verified source code and batch contract verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ module.exports = {
 This plugin gets compiler optimisation settings from the truffle config file, so make sure that your truffle config settings are the same as when your contracts were compiled.
 
 ## Donations
-If you''ve used this plugin and found it helpful in your workflow, please consider sending some Ξ or tokens to `0xe126b3E5d052f1F575828f61fEBA4f4f2603652a`.
+If you've used this plugin and found it helpful in your workflow, please consider sending some Ξ or tokens to `0xe126b3E5d052f1F575828f61fEBA4f4f2603652a`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This can take some time, and will eventually either return `Pass - Verified` or 
 
 ### Adding Preamble (Optional)
 
-There is also the option of adding some preamble to the beginning of your verified source code. This may be useful for adding authorship information, links to source code, or even versioning information.
+There is also the option of adding preamble to the beginning of your verified source code. This may be useful for adding authorship information, links to source code, copyright information, or versioning information.
 
 To do so, add to your `truffle.js` or `truffle-config.js` file
 ```js
@@ -63,7 +63,7 @@ module.exports = {
   /* ... rest of truffle-config */
 
   verify: {
-    preamble: "Your multiline compatible\npreamble text here!"
+    preamble: "Author: John Citizen.\nVersion: 1.0.1"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before running verification, make sure that you have actually deployed your cont
 After deployment, run the following command with one or more contracts which you wish to verify:
 
 ```
-truffle run verify SmartContractName AnotherContractName [--network networkName]
+truffle run verify SomeContractName AnotherContractName [--network networkName]
 ```
 
 The network parameter should correspond to a network defined in the Truffle config file, with the correct network id set. The Ethereum mainnet and all public testnets are supported.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ module.exports = {
 ```
 
 ## Usage
-Before running verification, make sure that you have actually deployed a contract to a public network with Truffle.
-After deployment, run the following command for every contract you wish to verify.
+Before running verification, make sure that you have actually deployed your contracts to a public network with Truffle.
+After deployment, run the following command with one or more contracts which you wish to verify:
 
 ```
-truffle run verify SmartContractName [--network networkName]
+truffle run verify SmartContractName AnotherContractName [--network networkName]
 ```
 
 The network parameter should correspond to a network defined in the Truffle config file, with the correct network id set. The Ethereum mainnet and all public testnets are supported.
@@ -50,7 +50,7 @@ For example, if we defined `rinkeby` as network in Truffle, and we wish to verif
 truffle run verify SimpleStorage --network rinkeby
 ```
 
-This can take some time, and will eventually either return `Pass - Verified` or `Fail - Unable to verify`. Since the information we get from the Etherscan API is quite limited, it is currently impossible to retrieve any more information on verification failure. There should be no reason though why the verification should fail if the usage is followed correctly. If you do receive a `Fail - Unable to verify` and you are sure that you followed the instructions correctly, please [open an issue](/issues/new) and I will look into it.
+This can take some time, and will eventually either return `Pass - Verified` or `Fail - Unable to verify` for each contract. Since the information we get from the Etherscan API is quite limited, it is currently impossible to retrieve any more information on verification failure. There should be no reason though why the verification should fail if the usage is followed correctly. If you do receive a `Fail - Unable to verify` and you are sure that you followed the instructions correctly, please [open an issue](/issues/new) and I will look into it.
 
 
 ### Adding Preamble (Optional)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ truffle run verify SimpleStorage --network rinkeby
 
 This can take some time, and will eventually either return `Pass - Verified` or `Fail - Unable to verify`. Since the information we get from the Etherscan API is quite limited, it is currently impossible to retrieve any more information on verification failure. There should be no reason though why the verification should fail if the usage is followed correctly. If you do receive a `Fail - Unable to verify` and you are sure that you followed the instructions correctly, please [open an issue](/issues/new) and I will look into it.
 
+
+### Adding Preamble (Optional)
+
+There is also the option of adding some preamble to the beginning of your verified source code. This may be useful for adding authorship information, links to source code, or even versioning information.
+
+To do so, add to your `truffle.js` or `truffle-config.js` file
+```js
+module.exports = {
+  /* ... rest of truffle-config */
+
+  verify: {
+    preamble: "Your multiline compatible\npreamble text here!"
+  }
+}
+```
+
 ## Notes
 This plugin gets compiler optimisation settings from the truffle config file, so make sure that your truffle config settings are the same as when your contracts were compiled.
 

--- a/docs/kalis-me-tutorial-code/truffle-config.js
+++ b/docs/kalis-me-tutorial-code/truffle-config.js
@@ -13,6 +13,9 @@ module.exports = {
   plugins: [
     'truffle-plugin-verify'
   ],
+  verify: {
+    preamble: "Hello world!\nThis is an example preamble at the top of the verified source code!\nIt is compatible with multiline strings."
+  },
   api_keys: {
     etherscan: process.env.ETHERSCAN_API_KEY
   }

--- a/verify.js
+++ b/verify.js
@@ -197,7 +197,7 @@ module.exports = async (config) => {
     }
   }
 
-  if (errorContracts) {
+  if (errorContracts.length > 0) {
     console.error(`\nFailed to verify: ${errorContracts.join(', ')}`)
     process.exit(1)
   }

--- a/verify.js
+++ b/verify.js
@@ -81,7 +81,7 @@ const sendVerifyRequest = async (artifact, options) => {
   })
 
   try {
-    return await axios.post(
+    return axios.post(
       options.apiUrl,
       querystring.stringify(postQueries)
     )

--- a/verify.js
+++ b/verify.js
@@ -180,5 +180,6 @@ module.exports = async (config) => {
     }
   } catch (e) {
     console.error(e.message)
+    process.exit(1)
   }
 }

--- a/verify.js
+++ b/verify.js
@@ -41,11 +41,12 @@ const fetchConstructorValues = async (artifact, options) => {
 
 const fetchMergedSource = async (artifact, options) => {
   let mergedSource = await merge(artifact.sourcePath)
-  // Include the preamble if it exists, removing instances of */ for safety
+  // Include the preamble if it exists, removing all instances of */ for safety
   if (options.verifyPreamble) {
     mergedSource = `/**
-* ${options.verifyPreamble.replace(/\*\//g, '')}
+${options.verifyPreamble.replace(/\*+\/+/g, '')}
 */
+
 ${mergedSource}`
   }
   return mergedSource

--- a/verify.js
+++ b/verify.js
@@ -40,6 +40,10 @@ const fetchConstructorValues = async (artifact, options) => {
 }
 
 const fetchMergedSource = async (artifact, options) => {
+  if (!fs.existsSync(artifact.sourcePath)) {
+    throw new Error(`Could not find source file: ${artifact.sourcePath}`)
+  }
+
   let mergedSource = await merge(artifact.sourcePath)
   // Include the preamble if it exists, removing all instances of */ for safety
   if (options.verifyPreamble) {

--- a/verify.js
+++ b/verify.js
@@ -168,8 +168,7 @@ const verifyContract = async (options, contractName) => {
   } else if (res.data.status !== RequestStatus.OK) {
     throw new Error(res.data.result)
   } else {
-    const status = await verificationStatus(res.data.result, options)
-    console.log(status)
+    return verificationStatus(res.data.result, options)
   }
 }
 
@@ -190,7 +189,11 @@ module.exports = async (config) => {
   for (const contractName of contractNames) {
     console.log(`\nVerifying: ${contractName}`)
     try {
-      await verifyContract(options, contractName)
+      const result = await verifyContract(options, contractName)
+      if (result === VerificationStatus.FAILED) {
+        errorContracts.push(contractName)
+      }
+      console.log(result)
     } catch (e) {
       console.error(e.message)
       errorContracts.push(contractName)

--- a/verify.js
+++ b/verify.js
@@ -185,23 +185,23 @@ module.exports = async (config) => {
   // Verify each contract
   const contractNames = config._.slice(1)
   // Track which contracts failed verification
-  const errorContracts = []
+  const failedContracts = []
   for (const contractName of contractNames) {
     console.log(`\nVerifying: ${contractName}`)
     try {
       const result = await verifyContract(options, contractName)
       if (result === VerificationStatus.FAILED) {
-        errorContracts.push(contractName)
+        failedContracts.push(contractName)
       }
       console.log(result)
     } catch (e) {
       console.error(e.message)
-      errorContracts.push(contractName)
+      failedContracts.push(contractName)
     }
   }
 
-  if (errorContracts.length > 0) {
-    console.error(`\nFailed to verify ${errorContracts.length} contract(s): ${errorContracts.join(', ')}`)
+  if (failedContracts.length > 0) {
+    console.error(`\nFailed to verify ${failedContracts.length} contract(s): ${failedContracts.join(', ')}`)
     process.exit(1)
   }
 

--- a/verify.js
+++ b/verify.js
@@ -198,9 +198,9 @@ module.exports = async (config) => {
   }
 
   if (errorContracts.length > 0) {
-    console.error(`\nFailed to verify: ${errorContracts.join(', ')}`)
+    console.error(`\nFailed to verify ${errorContracts.length} contract(s): ${errorContracts.join(', ')}`)
     process.exit(1)
   }
 
-  console.log('\nVerification finished successfully.')
+  console.log(`\nSuccessfully verified ${contractNames.length} contract(s).`)
 }

--- a/verify.js
+++ b/verify.js
@@ -48,7 +48,7 @@ const fetchMergedSource = async (artifact, options) => {
   // Include the preamble if it exists, removing all instances of */ for safety
   if (options.verifyPreamble) {
     mergedSource = `/**
-${options.verifyPreamble.replace(/\*+\/+/g, '')}
+${options.verifyPreamble.replace(/\*+\//g, '')}
 */
 
 ${mergedSource}`

--- a/verify.js
+++ b/verify.js
@@ -129,7 +129,11 @@ const parseConfig = (config) => {
   const workingDir = config.working_directory
   const contractsBuildDir = config.contracts_build_directory
   const optimizerSettings = config.compilers.solc.settings.optimizer
-  const verifyPreamble = config.verify.preamble || "";
+
+  let verifyPreamble = ''
+  if (config.verify && config.verify.preamble) {
+    verifyPreamble = config.verify.preamble
+  }
 
   return {
     apiUrl,

--- a/verify.js
+++ b/verify.js
@@ -175,7 +175,7 @@ const verifyContract = async (options, contractName) => {
 
 module.exports = async (config) => {
   // Attempt to parse options
-  let options;
+  let options
   try {
     options = parseConfig(config)
   } catch (e) {


### PR DESCRIPTION
This PR adds the ability to specify `verify.preamble` in the `truffle` configuration and have that be prepended to the source code for verification. This is useful for including to the verified source code authorship information, useful links, copyright or version information.

Additionally, this PR also adds support for batch contract verification, by passing multiple contract names to `truffle verify`.