### PR TITLE
Update contract source paths for Windows so Windows can find the files

### DIFF
--- a/test/metacoin/contracts/ConvertLib.sol
+++ b/test/metacoin/contracts/ConvertLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.25 <0.7.0;
+pragma solidity >=0.4.25 <0.9.0;
 
 library ConvertLib {
 	struct TestStruct {

--- a/test/metacoin/contracts/MetaCoin.sol
+++ b/test/metacoin/contracts/MetaCoin.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma experimental ABIEncoderV2;
-pragma solidity >=0.4.25 <0.7.0;
+pragma solidity >=0.4.25 <0.9.0;
 
 import "./ConvertLib.sol";
 

--- a/test/metacoin/contracts/Migrations.sol
+++ b/test/metacoin/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.25 <0.7.0;
+pragma solidity >=0.4.25 <0.9.0;
 
 contract Migrations {
   address public owner;

--- a/test/metacoin/contracts/WrappedMetaCoin.sol
+++ b/test/metacoin/contracts/WrappedMetaCoin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.25 <0.7.0;
+pragma solidity >=0.4.25 <0.9.0;
 
 import { MetaCoin as Coin } from "./MetaCoin.sol";
 

--- a/test/metacoin/truffle-config.js
+++ b/test/metacoin/truffle-config.js
@@ -4,7 +4,7 @@ require('dotenv').config()
 module.exports = {
   compilers: {
     solc: {
-      version: '0.6.11',
+      version: '0.7.0',
       settings: {
         optimizer: {
           enabled: true,
@@ -19,9 +19,17 @@ module.exports = {
     etherscan: process.env.ETHERSCAN_API_KEY
   },
   networks: {
+    ropsten: {
+      provider: () => {
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://ropsten.infura.io/ws/v3/${process.env.INFURA_ID}`)
+      },
+      gas: 0x7a1200,
+      network_id: 3,
+      skipDryRun: true
+    },
     rinkeby: {
       provider: () => {
-        return new HDWalletProvider(`${process.env.MNEMONIC}`, `https://rinkeby.infura.io/v3/${process.env.INFURA_ID}`)
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://rinkeby.infura.io/ws/v3/${process.env.INFURA_ID}`)
       },
       gas: 0x7a1200,
       network_id: 4,
@@ -29,7 +37,7 @@ module.exports = {
     },
     goerli: {
       provider: () => {
-        return new HDWalletProvider(`${process.env.MNEMONIC}`, `https://goerli.infura.io/v3/${process.env.INFURA_ID}`)
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://goerli.infura.io/ws/v3/${process.env.INFURA_ID}`)
       },
       gas: 0x7a1200,
       network_id: 5,

--- a/test/openzeppelin-token/truffle-config.js
+++ b/test/openzeppelin-token/truffle-config.js
@@ -12,9 +12,17 @@ module.exports = {
     etherscan: process.env.ETHERSCAN_API_KEY
   },
   networks: {
+    ropsten: {
+      provider: () => {
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://ropsten.infura.io/ws/v3/${process.env.INFURA_ID}`)
+      },
+      gas: 0x7a1200,
+      network_id: 3,
+      skipDryRun: true
+    },
     rinkeby: {
       provider: () => {
-        return new HDWalletProvider(`${process.env.MNEMONIC}`, `https://rinkeby.infura.io/v3/${process.env.INFURA_ID}`)
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://rinkeby.infura.io/ws/v3/${process.env.INFURA_ID}`)
       },
       gas: 0x7a1200,
       network_id: 4,
@@ -22,7 +30,7 @@ module.exports = {
     },
     goerli: {
       provider: () => {
-        return new HDWalletProvider(`${process.env.MNEMONIC}`, `https://goerli.infura.io/v3/${process.env.INFURA_ID}`)
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://goerli.infura.io/ws/v3/${process.env.INFURA_ID}`)
       },
       gas: 0x7a1200,
       network_id: 5,

--- a/util.js
+++ b/util.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const abort = (message, logger = console, code = 1) => {
   logger.error(message)
   process.exit(code)
@@ -12,26 +14,25 @@ const enforceOrThrow = (condition, message) => {
 }
 
 /**
- * For some reason, the metadata in the Truffle artifact file mangles source paths on Windows.
- * Instead of D:/Hello/World.sol, it looks like /D/Hello/World.sol. When trying to read this path,
- * Windows cannot find it, since it is not a valid path. This function changes /D/Hello/World.sol
- * to D:/Hello/World.sol, and does not change non-Windows paths.
+ * The metadata in the Truffle artifact file changes source paths on Windows. Instead of
+ * D:\Hello\World.sol, it looks like /D/Hello/World.sol. When trying to read this path,
+ * Windows cannot find it, since it is not a valid path. This function changes
+ * /D/Hello/World.sol to D:\Hello\World.sol. This way, Windows is able to read these source
+ * files. It does not change regular Unix paths, only Unixified Windows paths. It also does
+ * not make any changes on platforms that aren't Windows.
  *
- * @param {string} contractPath path to a contract file.
- * @param {any} logger cliLogger instance.
- * @returns {string} normalised path to the contract.
+ * @param {string} contractPath path to a contract file in any format.
+ * @returns {string} path to the contract in Windows format when on Windows, or Unix format otherwise.
  */
-const normaliseContractPath = (contractPath, logger) => {
-  // If the current platform is not Windows, the contract does not need to be changed
+const normaliseContractPath = (contractPath) => {
+  // If the current platform is not Windows, the path does not need to be changed
   if (process.platform !== 'win32') return contractPath
 
-  // If the contract path doesn't start with '/[A-Z]/' it is not a Windows path
+  // If the contract path doesn't start with '/[A-Z]/' it is not a Unixified Windows path
   if (!contractPath.match(/^\/[A-Z]\//i)) return contractPath
 
   const driveLetter = contractPath.substring(1, 2)
-  const normalisedContractPath = `${driveLetter}:/${contractPath.substring(3)}`
-
-  logger.debug(`Normalised contract path from ${contractPath} to ${normalisedContractPath}`)
+  const normalisedContractPath = path.resolve(`${driveLetter}:/${contractPath.substring(3)}`)
 
   return normalisedContractPath
 }

--- a/util.js
+++ b/util.js
@@ -11,8 +11,34 @@ const enforceOrThrow = (condition, message) => {
   if (!condition) throw new Error(message)
 }
 
+/**
+ * For some reason, the metadata in the Truffle artifact file mangles source paths on Windows.
+ * Instead of D:/Hello/World.sol, it looks like /D/Hello/World.sol. When trying to read this path,
+ * Windows cannot find it, since it is not a valid path. This function changes /D/Hello/World.sol
+ * to D:/Hello/World.sol, and does not change non-Windows paths.
+ *
+ * @param {string} contractPath path to a contract file.
+ * @param {any} logger cliLogger instance.
+ * @returns {string} normalised path to the contract.
+ */
+const normaliseContractPath = (contractPath, logger) => {
+  // If the current platform is not Windows, the contract does not need to be changed
+  if (process.platform !== 'win32') return contractPath
+
+  // If the contract path doesn't start with '/[A-Z]/' it is not a Windows path
+  if (!contractPath.match(/^\/[A-Z]\//i)) return contractPath
+
+  const driveLetter = contractPath.substring(1, 2)
+  const normalisedContractPath = `${driveLetter}:/${contractPath.substring(3)}`
+
+  logger.debug(`Normalised contract path from ${contractPath} to ${normalisedContractPath}`)
+
+  return normalisedContractPath
+}
+
 module.exports = {
   abort,
   enforce,
-  enforceOrThrow
+  enforceOrThrow,
+  normaliseContractPath
 }

--- a/verify.js
+++ b/verify.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const querystring = require('querystring')
 const { API_URLS, EXPLORER_URLS, RequestStatus, VerificationStatus } = require('./constants')
-const { enforce, enforceOrThrow } = require('./util')
+const { enforce, enforceOrThrow, normaliseContractPath } = require('./util')
 const { version } = require('./package.json')
 
 const logger = cliLogger({ level: 'info' })
@@ -199,7 +199,8 @@ const fetchInputJSON = async (artifact, options) => {
   }
 
   for (const contractPath in inputJSON.sources) {
-    const absolutePath = require.resolve(contractPath)
+    const normalisedContractPath = normaliseContractPath(contractPath, logger)
+    const absolutePath = require.resolve(normalisedContractPath)
     const content = fs.readFileSync(absolutePath, 'utf8')
     inputJSON.sources[contractPath] = { content }
   }

--- a/verify.js
+++ b/verify.js
@@ -126,7 +126,7 @@ const sendVerifyRequest = async (artifact, options) => {
     contractaddress: artifact.networks[`${options.networkId}`].address,
     sourceCode: JSON.stringify(inputJSON),
     codeformat: 'solidity-standard-json-input',
-    contractname: `${artifact.sourcePath}:${artifact.contractName}`,
+    contractname: `${artifact.ast.absolutePath}:${artifact.contractName}`,
     compilerversion: compilerVersion,
     constructorArguements: encodedConstructorArgs
   }
@@ -199,6 +199,7 @@ const fetchInputJSON = async (artifact, options) => {
   }
 
   for (const contractPath in inputJSON.sources) {
+    // If we're on Windows we need to de-Unixify the path so that Windows can read the file
     const normalisedContractPath = normaliseContractPath(contractPath, logger)
     const absolutePath = require.resolve(normalisedContractPath)
     const content = fs.readFileSync(absolutePath, 'utf8')


### PR DESCRIPTION
The metadata field in artifact JSON looks like `/D/Hello/World.sol`, but Windows expects it to look like `D:\Hello\World.sol`, so this updates the plugin to update these paths when reading the contract source code.