### PR TITLE
Add ftmscan.com support

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -5,7 +5,8 @@ const API_URLS = {
   5: 'https://api-goerli.etherscan.io/api',
   42: 'https://api-kovan.etherscan.io/api',
   56: 'https://api.bscscan.com/api',
-  97: 'https://api-testnet.bscscan.com/api'
+  97: 'https://api-testnet.bscscan.com/api',
+  250: 'https://api.ftmscan.com/api'
 }
 
 const EXPLORER_URLS = {
@@ -15,7 +16,10 @@ const EXPLORER_URLS = {
   5: 'https://goerli.etherscan.io/address',
   42: 'https://kovan.etherscan.io/address',
   56: 'https://bscscan.com/address',
-  97: 'https://testnet.bscscan.com/address'
+  97: 'https://testnet.bscscan.com/address',
+  250: 'https://ftmscan.com/address/',
+  4002: 'https://explorer.testnet.fantom.network/address'
+
 }
 
 const RequestStatus = {

--- a/constants.js
+++ b/constants.js
@@ -17,7 +17,7 @@ const EXPLORER_URLS = {
   42: 'https://kovan.etherscan.io/address',
   56: 'https://bscscan.com/address',
   97: 'https://testnet.bscscan.com/address',
-  250: 'https://ftmscan.com/address/',
+  250: 'https://ftmscan.com/address',
   4002: 'https://explorer.testnet.fantom.network/address'
 
 }

--- a/verify.js
+++ b/verify.js
@@ -72,8 +72,9 @@ const parseConfig = (config) => {
 
   const etherscanApiKey = config.api_keys && config.api_keys.etherscan
   const bscscanApiKey = config.api_keys && config.api_keys.bscscan
+  const ftmscanApiKey = config.api_keys && config.api_keys.ftmscan
 
-  const apiKey = apiUrl.includes('bscscan') && bscscanApiKey ? bscscanApiKey : etherscanApiKey
+  const apiKey = apiUrl.includes('bscscan') && bscscanApiKey ? bscscanApiKey : apiUrl.includes('ftmscan') && ftmscanApiKey ? ftmscanApiKey : etherscanApiKey
   enforce(apiKey, 'No Etherscan API key specified', logger)
 
   enforce(config._.length > 1, 'No contract name(s) specified', logger)


### PR DESCRIPTION
Added support with Fantom Opera chain (Explorer: ftmscan.com built by the same team of ethscan and bscscan)