### PR TITLE
Fix separate api keys

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -71,7 +71,22 @@ const parseConfig = (config) => {
   const apiUrl = API_URLS[networkId]
   enforce(apiUrl, `Etherscan has no support for network ${config.network} with id ${networkId}`, logger)
 
-  const apiKey = config.api_keys && config.api_keys.etherscan
+  const etherscanApiKey = config.api_keys && config.api_keys.etherscan
+  const bscscanApiKey = config.api_keys && config.api_keys.bscscan
+  const hecoinfoApiKey = config.api_keys && config.api_keys.hecoinfo
+  const ftmscanApiKey = config.api_keys && config.api_keys.ftmscan
+  const polygonscanApiKey = config.api_keys && config.api_keys.polygonscan
+
+  const apiKey = apiUrl.includes('bscscan') && bscscanApiKey
+    ? bscscanApiKey
+    : apiUrl.includes('ftmscan') && ftmscanApiKey
+      ? ftmscanApiKey
+      : apiUrl.includes('hecoinfo') && hecoinfoApiKey
+        ? hecoinfoApiKey
+        : apiUrl.includes('polygonscan') && polygonscanApiKey
+          ? polygonscanApiKey
+          : etherscanApiKey
+
   enforce(apiKey, 'No Etherscan API key specified', logger)
 
   enforce(config._.length > 1, 'No contract name(s) specified', logger)


### PR DESCRIPTION
Currently, when we want to verify contracts on other chain, we need to update value in 'config.api_keys.etherscan'.
I cloned the code from branch master.
It will support separate API keys for multiple chains.