### PR TITLE
Fixes: The "path" argument must be of type string. Received type undefined.

### DIFF
--- a/util.js
+++ b/util.js
@@ -52,7 +52,8 @@ const getAbsolutePath = (contractPath, contractsDir) => {
 
   // Figure out the project path and use it to construct the absolute path
   const relativeContractPath = contractPath.replace('project:/', '')
-  const projectPath = findProjectPath(relativeContractPath, contractsDir)
+  const projectPath = findProjectPath(relativeContractPath, contractsDir) ||
+        findProjectPath(relativeContractPath, contractsDir.split('/').slice(0,-1).join('/') + "/node_modules/")
   const absolutePath = path.join(projectPath, relativeContractPath)
 
   return absolutePath


### PR DESCRIPTION

There's an issue with the way that source code is found ( referreneced in issue #101 ). If you're including solidity files from your node modules, this plugin won't find them. 

This fixes the problem, but I'm pretty sure there is a more eloquent way to solve this. Sorry for the ugly code.