### PR TITLE
Use proxy to access etherscan.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ I wrote a tutorial on my website that goes through the entire process of install
      }
    }
    ```
+5. Add proxy settings to your truffle config if necessary
+   ```js
+   module.exports = {
+     /* ... rest of truffle-config */
 
+     verify_proxy: { 
+       host: '127.0.0.1',
+       port: '1080'
+     }
+   }
+   ```
 ## Usage
 Before running verification, make sure that you have successfully deployed your contracts to a public network with Truffle. The contract deployment must have completely finished without errors, including the final step of "saving migration to chain," so that the artifact files are updated with the required information. If this final step fails, try lowering your global gas limit in your `truffle-config.js` file, as saving migrations to chain uses your global gas limit and gas price, which could be problematic if you do not have sufficient ETH in your wallet to cover this maximum hypothetical cost.
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,7 @@ I wrote a tutorial on my website that goes through the entire process of install
      }
    }
    ```
-5. Add proxy settings to your truffle config if necessary
-   ```js
-   module.exports = {
-     /* ... rest of truffle-config */
 
-     verify_proxy: { 
-       host: '127.0.0.1',
-       port: '1080'
-     }
-   }
-   ```
 ## Usage
 Before running verification, make sure that you have successfully deployed your contracts to a public network with Truffle. The contract deployment must have completely finished without errors, including the final step of "saving migration to chain," so that the artifact files are updated with the required information. If this final step fails, try lowering your global gas limit in your `truffle-config.js` file, as saving migrations to chain uses your global gas limit and gas price, which could be problematic if you do not have sufficient ETH in your wallet to cover this maximum hypothetical cost.
 
@@ -77,6 +67,21 @@ You can optionally provide an explicit address of the contract(s) that you wish 
 ```
 truffle run verify SimpleStorage@0x61C9157A9EfCaf6022243fA65Ef4666ECc9FD3D7 --network rinkeby
 ```
+
+### Run with a proxy (Optional)
+In some cases the Etherscan website may not be directly accessible. In this case it is possible to configure proxy settings so that the Etherscan requests will be made through this proxy. To use this feature, please add the relevant proxy settings to your truffle-config under `proxy.verify`.
+   ```js
+   module.exports = {
+     /* ... rest of truffle-config */
+
+     verify: {
+       proxy: {
+        host: '127.0.0.1',
+        port: '1080'
+      }
+     }
+   }
+   ```
 
 ### Constructor arguments override (Optional)
 You can additionally provide an explicit constructor arguments for the contract using the `--forceConstructorArgs` option. This is useful if the contract was created by another contract rather an EOA, because truffle-plugin-verify cannot automatically retrieve constructor arguments in these cases. Note that the value needs to be prefixed with `string:` (e.g. `--forceConstructorArgs string:0000`).

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "axios": "^0.21.1",
     "cli-logger": "^0.5.40",
     "delay": "^5.0.0",
-    "querystring": "^0.2.1"
+    "querystring": "^0.2.1",
+    "tunnel": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/verify.js
+++ b/verify.js
@@ -18,7 +18,7 @@ module.exports = async (config) => {
   logger.debug(`Running truffle-plugin-verify v${version}`)
 
   if (config.verify && config.verify.proxy) {
-    logger.debug('Enable verify proxy ', config.verify_proxy)
+    logger.debug('Enable verify proxy ', config.verify.proxy)
     const { proxy } = config.verify
     axios.interceptors.request.use((conf) => {
       conf.httpsAgent = tunnel.httpsOverHttp({ proxy })

--- a/verify.js
+++ b/verify.js
@@ -17,15 +17,11 @@ module.exports = async (config) => {
   logger.debug('DEBUG logging is turned ON')
   logger.debug(`Running truffle-plugin-verify v${version}`)
 
-  if (config.verify_proxy) {
+  if (config.verify && config.verify.proxy) {
     logger.debug('Enable verify proxy ', config.verify_proxy)
-    axios.interceptors.request.use(function (conf) {
-      conf.httpsAgent = tunnel.httpsOverHttp({
-        proxy: {
-          host: config.verify_proxy.host,
-          port: config.verify_proxy.port
-        }
-      })
+    const { proxy } = config.verify
+    axios.interceptors.request.use((conf) => {
+      conf.httpsAgent = tunnel.httpsOverHttp({ proxy })
       conf.proxy = false
       return conf
     })

--- a/verify.js
+++ b/verify.js
@@ -18,8 +18,8 @@ module.exports = async (config) => {
   logger.debug(`Running truffle-plugin-verify v${version}`)
 
   if (config.verify && config.verify.proxy) {
-    logger.debug('Enable verify proxy ', config.verify.proxy)
     const { proxy } = config.verify
+    logger.debug('Enable verify proxy ', proxy)
     axios.interceptors.request.use((conf) => {
       conf.httpsAgent = tunnel.httpsOverHttp({ proxy })
       conf.proxy = false

--- a/verify.js
+++ b/verify.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const tunnel = require('tunnel')
 const cliLogger = require('cli-logger')
 const delay = require('delay')
 const fs = require('fs')
@@ -15,6 +16,20 @@ module.exports = async (config) => {
   if (config.debug) logger.level('debug')
   logger.debug('DEBUG logging is turned ON')
   logger.debug(`Running truffle-plugin-verify v${version}`)
+
+  if (config.verify_proxy) {
+    logger.debug('Enable verify proxy ', config.verify_proxy)
+    axios.interceptors.request.use(function (conf) {
+      conf.httpsAgent = tunnel.httpsOverHttp({
+        proxy: {
+          host: config.verify_proxy.host,
+          port: config.verify_proxy.port
+        }
+      })
+      conf.proxy = false
+      return conf
+    })
+  }
 
   const options = await parseConfig(config)
 


### PR DESCRIPTION
Hello Rosco Kalis
In China etherscan.io cannot be accessed unless use a proxy(just like google.com, youtube.com, etc.)

like this
https://github.com/rkalis/truffle-plugin-verify/issues/39
https://github.com/rkalis/truffle-plugin-verify/issues/40

Before using a proxy
![image](https://user-images.githubusercontent.com/38126138/146926715-3cd06126-bf39-4912-a9e7-80995bb98be2.png)

![image](https://user-images.githubusercontent.com/38126138/146918947-171536a3-1c2f-401f-a031-957d67449411.png)

After using proxy(Add proxy settings to truffle config)
![image](https://user-images.githubusercontent.com/38126138/146919005-1ae71d81-a5c0-46af-93dd-fa28959605f0.png)

![image](https://user-images.githubusercontent.com/38126138/146926832-7f848e1e-2d6a-4352-a18d-87d547c7f46e.png)