### PR TITLE
Check that network_id is not "*"

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -108,6 +108,7 @@ const parseConfig = async (config) => {
 
   enforce(apiKey, 'No Etherscan API key specified', logger)
   enforce(config._.length > 1, 'No contract name(s) specified', logger)
+  enforce(networkId !== "*",'network_id bypassed with "*" in truffle-config.js.',logger)
 
   const projectDir = config.working_directory
   const contractsBuildDir = config.contracts_build_directory

--- a/verify.js
+++ b/verify.js
@@ -38,6 +38,11 @@ module.exports = async (config) => {
         artifact.networks[`${options.networkId}`].address = contractAddress
       }
 
+      enforceOrThrow(
+        artifact.networks && artifact.networks[`${options.networkId}`],
+        `No instance of contract ${artifact.contractName} found for chain id ${options.networkId}`
+      )
+
       const proxyImplementationAddress = await getImplementationAddress(
         options.provider,
         artifact.networks[`${options.networkId}`].address,
@@ -139,11 +144,6 @@ const getArtifact = (contractName, options) => {
 }
 
 const verifyContract = async (artifact, options) => {
-  enforceOrThrow(
-    artifact.networks && artifact.networks[`${options.networkId}`],
-    `No instance of contract ${artifact.contractName} found for network id ${options.networkId}`
-  )
-
   const res = await sendVerifyRequest(artifact, options)
   enforceOrThrow(res.data, `Failed to connect to Etherscan API at url ${options.apiUrl}`)
 


### PR DESCRIPTION
Hey Rosco, I have added a message for `network_id:"*"`  in `truffle-config.js` case.