### PR TITLE
Allow custom api and explorer urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can pass an optional `--debug` flag into the plugin to display debug message
 truffle run verify SimpleStorage --network rinkeby
 ```
 
-### Usage with other chains
+### Usage with supported chains
 These instructions were written for verification on Etherscan for Ethereum mainnet and testnets, but it also works for verification on other platforms for other chains. To verify your contracts on these chains make sure that your `truffle-config.js` file contains a network config for your preferred network. Also make sure that you request an API key from the platform that you're using and add it to your `truffle-config.js` file. If you want to verify your contracts on multiple chains, please provide separate API keys.
 
 ```js
@@ -137,6 +137,27 @@ module.exports = {
 - [BTTCScan](https://bttcscan.com/) (BitTorrent Mainnet & Donau Testnet)
 - [Aurorascan](https://aurorascan.dev/) (Aurora Mainnet & Testnet)
 - [Cronoscan](https://cronoscan.com) (Cronos Mainnet)
+
+### Usage with unsupported chains
+In cases where the platform you want to use supports an Etherscan compatible API but is not listed above, you may manually specify the `apiUrl` and `explorerUrl` (optional) for the platform. To use this feature, please add the relevant settings to your truffle-config under `networks.<name of your network>.verify`.
+
+```js
+module.exports = {
+  /* ... rest of truffle-config */
+
+  networks: {
+    /* ... other networks */
+  
+    network_with_custom_platform: {
+      verify: {
+        apiUrl: 'http://localhost:4000/api',
+        apiKey: 'MY_API_KEY',
+        explorerUrl: 'http://localhost:4000/address',
+      }
+    }
+  }
+}
+```
 
 ## Notes
 This plugin has a naming conflict with the truffle-security plugin, so when using both truffle-security and truffle-plugin-verify in the same project, `truffle run etherscan` can be used instead of `truffle run verify` for truffle-plugin-verify.

--- a/constants.js
+++ b/constants.js
@@ -76,7 +76,7 @@ const StorageSlot = {
   BEACON: '0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50'
 }
 
-const STORAGE_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000'
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 module.exports = {
   API_URLS,
@@ -84,5 +84,5 @@ module.exports = {
   RequestStatus,
   VerificationStatus,
   StorageSlot,
-  STORAGE_ZERO
+  NULL_ADDRESS
 }

--- a/test/openzeppelin-token/truffle-config.js
+++ b/test/openzeppelin-token/truffle-config.js
@@ -10,7 +10,6 @@ module.exports = {
           enabled: true,
           runs: 200
         },
-        evmVersion: 'default'
       }
     }
   },
@@ -46,6 +45,18 @@ module.exports = {
       gas: 0x7a1200,
       network_id: 5,
       skipDryRun: true
+    },
+    'goerli-custom': {
+      provider: () => {
+        return new HDWalletProvider(`${process.env.MNEMONIC}`, `wss://goerli.infura.io/ws/v3/${process.env.INFURA_ID}`)
+      },
+      gas: 0x7a1200,
+      network_id: 5,
+      skipDryRun: true,
+      verify: {
+        apiUrl: 'https://api-goerli.etherscan.io/api',
+        apiKey: process.env.ETHERSCAN_API_KEY
+      }
     },
     polygon: {
       provider: () => {

--- a/util.js
+++ b/util.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { promisify } = require('util')
-const { StorageSlot, STORAGE_ZERO } = require('./constants')
+const { StorageSlot, NULL_ADDRESS } = require('./constants')
 
 const abort = (message, logger = console, code = 1) => {
   logger.error(message)
@@ -123,8 +123,10 @@ const getImplementationAddress = async (provider, address, logger) => {
       params: [address, StorageSlot.LOGIC, 'latest']
     })
 
-    if (typeof result === 'string' && result !== STORAGE_ZERO) {
-      return getAddressFromStorage(result)
+    const implementationAddress = getAddressFromStorage(result)
+
+    if (typeof result === 'string' && implementationAddress !== NULL_ADDRESS) {
+      return implementationAddress
     }
   } catch {
     // ignored
@@ -148,7 +150,7 @@ const getRpcSendFunction = (provider) => (
 
 const deepCopy = (obj) => JSON.parse(JSON.stringify(obj))
 
-const getAddressFromStorage = (storage) => `0x${storage.slice(12 * 2 + 2)}`
+const getAddressFromStorage = (storage) => `0x${storage.slice(2).slice(-40).padStart(40, '0')}`
 
 const getApiKey = (config, apiUrl, logger) => {
   const networkConfig = config.networks[config.network]

--- a/util.js
+++ b/util.js
@@ -151,6 +151,11 @@ const deepCopy = (obj) => JSON.parse(JSON.stringify(obj))
 const getAddressFromStorage = (storage) => `0x${storage.slice(12 * 2 + 2)}`
 
 const getApiKey = (config, apiUrl, logger) => {
+  const networkConfig = config.networks[config.network]
+  if (networkConfig && networkConfig.verify && networkConfig.verify.apiKey) {
+    return networkConfig.verify.apiKey
+  }
+
   enforce(config.api_keys, 'No API Keys provided', logger)
 
   if (apiUrl.includes('bscscan')) return getApiKeyForPlatform(config, 'BscScan', logger)


### PR DESCRIPTION
This PR allow specifying custom API and explorer URLs

Sample configuration:
```js
// truffle-config.js

module.exports = {
  networks: {
    development: {
      host: 'localhost',
      port: 8545,
      network_id: '*',
      verify: {
        apiUrl: 'http://localhost:4000/api',
        apiKey: 'TEST_KEY',
        explorerUrl: 'http://localhost:4000/address',
      }
    },
  },
};
```

Currently a API key needs to be provided even if the block explorer does not need one. Should I make the API key optional?